### PR TITLE
Fix/Jenkins Scenario: Remove additional string "jenkins" in scenario vars

### DIFF
--- a/Components/io/Jenkins/docker-compose.yml
+++ b/Components/io/Jenkins/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 
 services:
   once.sh:
-    container_name: ${SCENARIO_NAME}_jenkins_container
-    image: ${SCENARIO_NAME}_jenkins_image
+    container_name: ${SCENARIO_NAME}_container
+    image: ${SCENARIO_NAME}_image
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - jenkins_home:/var/jenkins_home

--- a/Components/io/Jenkins/scenario.sh
+++ b/Components/io/Jenkins/scenario.sh
@@ -45,7 +45,7 @@ function up() {
     # Create jenkins image
     banner "Create jenkins image"
     log "Building image..."
-    docker build -t ${SCENARIO_NAME}_jenkins_image . > $VERBOSEPIPE
+    docker build -t ${SCENARIO_NAME}_image . > $VERBOSEPIPE
 
     # Create and run container
     banner "Create and run container"
@@ -92,11 +92,11 @@ function test() {
     if [ "$VERBOSITY" = "-v" ]; then
         banner "Test"
         log "Volumes:"
-        docker volume ls | grep ${SCENARIO_NAME}_jenkins_home
+        docker volume ls | grep ${SCENARIO_NAME}_home
         log "Images:"
-        docker image ls | grep ${SCENARIO_NAME}_jenkins_image
+        docker image ls | grep ${SCENARIO_NAME}_image
         log "Containers:"
-        docker ps -all | grep ${SCENARIO_NAME}_jenkins_container
+        docker ps -all | grep ${SCENARIO_NAME}_container
     fi
 
     # Check EAMD.ucp git status


### PR DESCRIPTION
This PR is a suggestion and still Work In Progress (WIP). The double string "jenkins" is still existing for volumes, so it should be safe for now.