### PR TITLE
Feature/linked certs

### DIFF
--- a/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/defaults.scenario.yaml
+++ b/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/defaults.scenario.yaml
@@ -25,9 +25,9 @@ scenario:
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
     # Where to find the servers letsencrypt base dir?
-    letsencryptdir: "/var/dev/ssl/data/certbot"
+    letsencryptdir: /var/dev/ssl/data/certbot
     # Where to find the servers certificate?
-    certificatedir: "/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
+    certificatedir: /var/dev/ssl/data/certbot/conf/live/test.wo-da.de
 
   ## Unique resources
   resource:

--- a/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/defaults.scenario.yaml
+++ b/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/defaults.scenario.yaml
@@ -24,6 +24,8 @@ scenario:
     sshconfig: WODA.test
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
+    # Where to find the servers letsencrypt base dir?
+    letsencryptdir: "/var/dev/ssl/data/certbot"
     # Where to find the servers certificate?
     certificatedir: "/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 

--- a/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/defaults.scenario.yaml
+++ b/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/defaults.scenario.yaml
@@ -25,7 +25,7 @@ scenario:
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
     # Where to find the servers certificate?
-    certificatedir: /tmp/conf/live/test.wo-da.de
+    certificatedir: "/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 
   ## Unique resources
   resource:

--- a/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/docker-compose.yml
+++ b/Components/com/ceruleanCircle/EAM/2_systems/WODA-with-Structr/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - /run/snapd.socket:/run/snapd.socket
       - ${SCENARIO_ONCE_VOLUME_NAME}:/var/dev
       - ${SCENARIO_SRC_ONCE_OUTERCONFIG}:/outer-config
-      - ${SCENARIO_SERVER_CERTIFICATEDIR}/fullchain.pem:/${ONCE_DEFAULT_SCENARIO}/once.cert.pem:ro
-      - ${SCENARIO_SERVER_CERTIFICATEDIR}/privkey.pem:/${ONCE_DEFAULT_SCENARIO}/once.key.pem:ro
     ports:
       - ${SCENARIO_RESOURCE_ONCE_HTTP}:8080
       - ${SCENARIO_RESOURCE_ONCE_HTTPS}:8443

--- a/Components/io/Jenkins/defaults.scenario.yaml
+++ b/Components/io/Jenkins/defaults.scenario.yaml
@@ -12,6 +12,8 @@ scenario:
     sshconfig: WODA.test
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
+    # Where to find the servers letsencrypt base dir?
+    #letsencryptdir: "/var/dev/ssl/data/certbot"
     # Where to find the servers certificate?
     #certificatedir: none
 

--- a/Components/io/Jenkins/defaults.scenario.yaml
+++ b/Components/io/Jenkins/defaults.scenario.yaml
@@ -13,7 +13,7 @@ scenario:
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
     # Where to find the servers letsencrypt base dir?
-    #letsencryptdir: "/var/dev/ssl/data/certbot"
+    #letsencryptdir: /var/dev/ssl/data/certbot
     # Where to find the servers certificate?
     #certificatedir: none
 

--- a/Components/org/eff/Certbot/2.x/defaults.scenario.yaml
+++ b/Components/org/eff/Certbot/2.x/defaults.scenario.yaml
@@ -12,10 +12,12 @@ scenario:
     sshconfig: WODA.test
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
+    # Where to find the servers letsencrypt base dir?
+    letsencryptdir: "/var/dev/ssl/data/certbot"
     # Where to find the servers certificate?
-    certificatedir: /var/dev/ssl/data/certbot/
+    #certificatedir: none
 # TODO: Wie kann ich deploy-tools und diese vars und einige oben in ein DefaultComponent machen und dann die componente ableiten?
 #data_directory_type (local_directory | docker_volume))
 #data_directory_path
 #data_directory_backup_source # put into path if path is empty
-#delete_data_directory_on_stop (tru | false)
+#delete_data_directory_on_stop (true | false)

--- a/Components/org/eff/Certbot/2.x/defaults.scenario.yaml
+++ b/Components/org/eff/Certbot/2.x/defaults.scenario.yaml
@@ -13,4 +13,4 @@ scenario:
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
     # Where to find the servers certificate?
-    certificatedir: /var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/
+    certificatedir: /var/dev/ssl/data/certbot/

--- a/Components/org/eff/Certbot/2.x/defaults.scenario.yaml
+++ b/Components/org/eff/Certbot/2.x/defaults.scenario.yaml
@@ -13,7 +13,7 @@ scenario:
     # What is the scenarios root directory on the server?
     configsdir: /var/dev/ONCE.2023-Scenarios
     # Where to find the servers letsencrypt base dir?
-    letsencryptdir: "/var/dev/ssl/data/certbot"
+    letsencryptdir: /var/dev/ssl/data/certbot
     # Where to find the servers certificate?
     #certificatedir: none
 # TODO: Wie kann ich deploy-tools und diese vars und einige oben in ein DefaultComponent machen und dann die componente ableiten?

--- a/Components/org/eff/Certbot/2.x/docker-compose.yml
+++ b/Components/org/eff/Certbot/2.x/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     image: certbot/certbot:v2.11.0
     restart: unless-stopped
     volumes:
-      - ${SCENARIO_SERVER_CERTIFICATEDIR}/conf:/etc/letsencrypt
-      - ${SCENARIO_SERVER_CERTIFICATEDIR}/www:/var/www/certbot
+      - ${SCENARIO_SERVER_LETSENCRYPTDIR}/conf:/etc/letsencrypt
+      - ${SCENARIO_SERVER_LETSENCRYPTDIR}/www:/var/www/certbot
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"

--- a/Components/org/sysoev/nginx/1.x/defaults.scenario.yaml
+++ b/Components/org/sysoev/nginx/1.x/defaults.scenario.yaml
@@ -14,7 +14,9 @@ scenario:
     configsdir: /var/dev/ONCE.2023-Scenarios
     # Where to find the servers config?
     configdir: /var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/Nginx.v1.21.3/config/
+    # Where to find the servers letsencrypt base dir?
+    letsencryptdir: "/var/dev/ssl/data/certbot"
     # Where to find the servers certificate?
-    certificatedir: /var/dev/ssl/data/certbot/
+    #certificatedir: none
     # What is the servers network name?
     networkname: once-woda-network

--- a/Components/org/sysoev/nginx/1.x/defaults.scenario.yaml
+++ b/Components/org/sysoev/nginx/1.x/defaults.scenario.yaml
@@ -15,6 +15,6 @@ scenario:
     # Where to find the servers config?
     configdir: /var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/Nginx.v1.21.3/config/
     # Where to find the servers certificate?
-    certificatedir: /var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/
+    certificatedir: /var/dev/ssl/data/certbot/
     # What is the servers network name?
     networkname: once-woda-network

--- a/Components/org/sysoev/nginx/1.x/defaults.scenario.yaml
+++ b/Components/org/sysoev/nginx/1.x/defaults.scenario.yaml
@@ -15,7 +15,7 @@ scenario:
     # Where to find the servers config?
     configdir: /var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/Nginx.v1.21.3/config/
     # Where to find the servers letsencrypt base dir?
-    letsencryptdir: "/var/dev/ssl/data/certbot"
+    letsencryptdir: /var/dev/ssl/data/certbot
     # Where to find the servers certificate?
     #certificatedir: none
     # What is the servers network name?

--- a/Components/org/sysoev/nginx/1.x/docker-compose.yml
+++ b/Components/org/sysoev/nginx/1.x/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     restart: unless-stopped
     volumes:
       - ${SCENARIO_SERVER_CONFIGDIR}:/etc/nginx/conf.d/
-      - ${SCENARIO_SERVER_CERTIFICATEDIR}/conf:/etc/letsencrypt
-      - ${SCENARIO_SERVER_CERTIFICATEDIR}/www:/var/www/certbot
+      - ${SCENARIO_SERVER_LETSENCRYPTDIR}/conf:/etc/letsencrypt
+      - ${SCENARIO_SERVER_LETSENCRYPTDIR}/www:/var/www/certbot
     ports:
       - "80:80"
       - "443:443"

--- a/Scenarios/de/wo-da/test/certbot.scenario.env
+++ b/Scenarios/de/wo-da/test/certbot.scenario.env
@@ -9,4 +9,4 @@ SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/"
+SCENARIO_SERVER_CERTIFICATEDIR="var/dev/ssl/data/certbot/"

--- a/Scenarios/de/wo-da/test/certbot.scenario.env
+++ b/Scenarios/de/wo-da/test/certbot.scenario.env
@@ -8,5 +8,7 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers letsencrypt base dir?
+SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="var/dev/ssl/data/certbot/"
+# certificatedir: none

--- a/Scenarios/de/wo-da/test/demo.scenario.env
+++ b/Scenarios/de/wo-da/test/demo.scenario.env
@@ -18,6 +18,8 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers letsencrypt base dir?
+SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
 SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources

--- a/Scenarios/de/wo-da/test/demo.scenario.env
+++ b/Scenarios/de/wo-da/test/demo.scenario.env
@@ -19,7 +19,7 @@ SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/conf/live/test.wo-da.de"
+SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources
 # Which volume should be used (if srcpath is not set, none means a temporary volume will be created)?
 SCENARIO_RESOURCE_ONCE_VOLUME="none"

--- a/Scenarios/de/wo-da/test/dev-ci.scenario.env
+++ b/Scenarios/de/wo-da/test/dev-ci.scenario.env
@@ -18,6 +18,8 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers letsencrypt base dir?
+SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
 SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources

--- a/Scenarios/de/wo-da/test/dev-ci.scenario.env
+++ b/Scenarios/de/wo-da/test/dev-ci.scenario.env
@@ -19,7 +19,7 @@ SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/conf/live/test.wo-da.de"
+SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources
 # Which volume should be used (if srcpath is not set, none means a temporary volume will be created)?
 SCENARIO_RESOURCE_ONCE_VOLUME="none"

--- a/Scenarios/de/wo-da/test/dev-neom.scenario.env
+++ b/Scenarios/de/wo-da/test/dev-neom.scenario.env
@@ -18,6 +18,8 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers letsencrypt base dir?
+SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
 SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources

--- a/Scenarios/de/wo-da/test/dev-neom.scenario.env
+++ b/Scenarios/de/wo-da/test/dev-neom.scenario.env
@@ -19,7 +19,7 @@ SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/conf/live/test.wo-da.de"
+SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources
 # Which volume should be used (if srcpath is not set, none means a temporary volume will be created)?
 SCENARIO_RESOURCE_ONCE_VOLUME="none"

--- a/Scenarios/de/wo-da/test/dev.scenario.env
+++ b/Scenarios/de/wo-da/test/dev.scenario.env
@@ -18,6 +18,8 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers letsencrypt base dir?
+SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
 SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources

--- a/Scenarios/de/wo-da/test/dev.scenario.env
+++ b/Scenarios/de/wo-da/test/dev.scenario.env
@@ -19,7 +19,7 @@ SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/conf/live/test.wo-da.de"
+SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/conf/live/test.wo-da.de"
 ## Unique resources
 # Which volume should be used (if srcpath is not set, none means a temporary volume will be created)?
 SCENARIO_RESOURCE_ONCE_VOLUME="none"

--- a/Scenarios/de/wo-da/test/jenkins.scenario.env
+++ b/Scenarios/de/wo-da/test/jenkins.scenario.env
@@ -8,6 +8,8 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers letsencrypt base dir?
+# letsencryptdir: "/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
 # certificatedir: none
 ## Unique resources

--- a/Scenarios/de/wo-da/test/nginx.scenario.env
+++ b/Scenarios/de/wo-da/test/nginx.scenario.env
@@ -8,6 +8,8 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
+# Where to find the servers config?
+SCENARIO_SERVER_CONFIGDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/Nginx.v1.21.3/config/"
 # Where to find the servers letsencrypt base dir?
 SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?

--- a/Scenarios/de/wo-da/test/nginx.scenario.env
+++ b/Scenarios/de/wo-da/test/nginx.scenario.env
@@ -8,9 +8,9 @@ SCENARIO_SERVER_NAME="test.wo-da.de"
 SCENARIO_SERVER_SSHCONFIG="WODA.test"
 # What is the scenarios root directory on the server?
 SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
-# Where to find the servers config?
-SCENARIO_SERVER_CONFIGDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/Nginx.v1.21.3/config/"
+# Where to find the servers letsencrypt base dir?
+SCENARIO_SERVER_LETSENCRYPTDIR="/var/dev/ssl/data/certbot"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/"
+# certificatedir: none
 # What is the servers network name?
 SCENARIO_SERVER_NETWORKNAME="once-woda-network"

--- a/Scenarios/de/wo-da/test/nginx.scenario.env
+++ b/Scenarios/de/wo-da/test/nginx.scenario.env
@@ -11,6 +11,6 @@ SCENARIO_SERVER_CONFIGSDIR="/var/dev/ONCE.2023-Scenarios"
 # Where to find the servers config?
 SCENARIO_SERVER_CONFIGDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/Nginx.v1.21.3/config/"
 # Where to find the servers certificate?
-SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/EAMD.ucp/Scenarios/de/1blu/v36421/vhosts/de/wo-da/test/EAM/1_infrastructure/Docker/CertBot.v1.7.0/config/"
+SCENARIO_SERVER_CERTIFICATEDIR="/var/dev/ssl/data/certbot/"
 # What is the servers network name?
 SCENARIO_SERVER_NETWORKNAME="once-woda-network"

--- a/Units/deploy-tools/deploy-tools.sh
+++ b/Units/deploy-tools/deploy-tools.sh
@@ -3,7 +3,7 @@
 # TODO: Define which variables are expected of give then as arguments
 
 # Check docker-compose command
-if docker compose version; then
+if docker compose version > /dev/null 2>&1; then
   # Switch from "docker-compose" to "docker compose"
   shopt -s expand_aliases # enables expanding aliases for current script
   alias docker-compose='docker compose'

--- a/scenario.deploy
+++ b/scenario.deploy
@@ -404,6 +404,24 @@ EOF
       RSYNC_VERBOSE="-v"
     fi
     rsync -azP $RSYNC_VERBOSE --exclude=_data --delete -e "ssh $use_key -o 'StrictHostKeyChecking no'" $LOCAL_CONFIG_DIR/ $SCENARIO_SERVER_SSHCONFIG:$REMOTE_CONFIG_DIR/
+
+    # Create certbot renewal-hook deploy script
+    if [ -n "$SCENARIO_SERVER_LETSENCRYPTDIR" ] && [ -n "$SCENARIO_SERVER_CERTIFICATEDIR" ] && [ "$SCENARIO_SERVER_CERTIFICATEDIR"!="none" ]; then
+      local deploy_hook="$SCENARIO_SERVER_LETSENCRYPTDIR/conf/renewal-hooks/deploy/${SCENARIO_NAME_SPACE//\//.}.$SCENARIO_NAME-scenario.sh"
+
+      # declare script content for remote file
+      cat << EOF | ssh $use_key -o 'StrictHostKeyChecking no' $SCENARIO_SERVER_SSHCONFIG "cat > $deploy_hook"
+#!/usr/bin/env bash
+
+pushd $SCENARIO_SERVER_CONFIGSDIR/$SCENARIO_NAME_SPACE/$SCENARIO_NAME
+./scenario.sh stop,start -s
+popd
+EOF
+
+      # mark script executable of remote file
+      ssh $use_key -o 'StrictHostKeyChecking no' $SCENARIO_SERVER_SSHCONFIG "chmod +x $deploy_hook"
+    fi
+
     log "Scenario '$SCENARIO_NAME' is now inited (available on remote server)."
   else
     log "Scenario '$SCENARIO_NAME' is now inited (local only)."
@@ -502,6 +520,12 @@ function deinit() {
   rm -rf $LOCAL_CONFIG_DIR
   rmdir -p $SCENARIOS_DIR_LOCAL/$SCENARIO_NAME_SPACE 2> /dev/null || true
   if ! isLocal; then
+    # remove remote renewal-hook deploy script
+    if [ -n "$SCENARIO_SERVER_LETSENCRYPTDIR" ] && [ -n "$SCENARIO_SERVER_CERTIFICATEDIR" ] && [ "$SCENARIO_SERVER_CERTIFICATEDIR"!="none" ]; then
+      local deploy_hook="$SCENARIO_SERVER_LETSENCRYPTDIR/conf/renewal-hooks/deploy/${SCENARIO_NAME_SPACE//\//.}.$SCENARIO_NAME-scenario.sh"
+      ssh $use_key -o 'StrictHostKeyChecking no' $SCENARIO_SERVER_SSHCONFIG "rm -f $deploy_hook"
+    fi
+
     ssh $use_key -o 'StrictHostKeyChecking no' $SCENARIO_SERVER_SSHCONFIG bash -s << EOF
             cd $SCENARIO_SERVER_CONFIGSDIR
             rm -rf $SCENARIO_NAME_SPACE/$SCENARIO_NAME


### PR DESCRIPTION
Changed **certificatedir** from `/var/dev/EAMD.ucp/...` to `/var/dev/ssl/...`.
Fixed creation of certificates.
Scenarios which use **certificatedir** are installing deploy renewal hook script for certbot.