### PR TITLE
Fix docker.sock permissions

### DIFF
--- a/Components/io/jenkins/2.x/Dockerfile
+++ b/Components/io/jenkins/2.x/Dockerfile
@@ -1,4 +1,4 @@
 FROM jenkins/jenkins:2.474-jdk17
 USER root
-RUN apt-get update && apt-get install -y docker.io docker-compose
+RUN apt-get update && apt-get install -y docker.io docker-compose acl
 USER jenkins

--- a/Components/io/jenkins/2.x/scenario.sh
+++ b/Components/io/jenkins/2.x/scenario.sh
@@ -50,6 +50,7 @@ function up() {
       groupadd -g $GROUP_ID dockerofhost
       usermod -aG dockerofhost jenkins
       usermod -aG docker jenkins
+      setfacl -m user:jenkins:rw /var/run/docker.sock
     else
       echo "Group dockerofhost already exists"
     fi


### PR DESCRIPTION
After reboot of WODA.test the /var/run/docker.sock permissions are set to 660. Jenkins has no permissions to rw on that socket from within its container.